### PR TITLE
Potential fixes for 3 code scanning alerts

### DIFF
--- a/.github/workflows/combine_prs.yml
+++ b/.github/workflows/combine_prs.yml
@@ -1,4 +1,7 @@
 name: 'Combine PRs'
+permissions:
+  contents: read
+  pull-requests: write
 
 # Controls when the action will run - in this case triggered manually
 on:

--- a/.github/workflows/generate_dependabot.yml
+++ b/.github/workflows/generate_dependabot.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
   repository_dispatch:
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As part of the organization's transition to default read-only permissions for the GITHUB_TOKEN, this pull request addresses a missing permission in the workflow that triggered a code scanning alert.

This PR explicitly adds the required read permissions to align with the default read only permission and is part of a larger effort for this OKR https://github.com/github/security-services/issues/455



Potential fixes for 3 code scanning alerts from the [Copilot AutoFix: Missing Permissions in Workflows](https://github.com/orgs/github/security/campaigns/20) security campaign:
- https://github.com/github/generate-dependabot-glob-action/security/code-scanning/3
To fix this issue, you should add the `permissions` key to the workflow, either at the root (to apply to all jobs) or at the individual job level (`combine-prs`). Since this workflow appears to only need to read repository contents and to create/modify pull requests, you should specify `contents: read` and `pull-requests: write`. Add the following block directly after the workflow `name` and before the `on:` key as per GitHub recommendations. No change to workflow functionality is required: just limit the GITHUB_TOKEN permissions as needed.

  ---
  


- https://github.com/github/generate-dependabot-glob-action/security/code-scanning/2
To resolve the issue, you should explicitly declare a `permissions` block in the workflow to restrict the GITHUB_TOKEN used by this workflow. Since the workflow appears to involve release automation—potentially updating contents on the repository—using `contents: write` makes sense, but if release publishing only reads contents (e.g., tags, versioning), then `contents: read` is sufficient. As a starting point, add the permissions block with `contents: read`, then later adjust based on what "Do release" requires. Place the `permissions` block at the workflow root level, above the `jobs:` key, so that it applies to all jobs by default.

  ---
  


- https://github.com/github/generate-dependabot-glob-action/security/code-scanning/1
The best way to fix this issue is to explicitly add a `permissions` block at the appropriate level in the workflow YAML. Since only the "Create Pull Request" step needs to write to contents and pull requests, and the other steps need only read access, it's cleanest to set the minimal required permissions at the job or workflow level.  
  - At the root level (outside `jobs:`), we set default minimal permissions, e.g., `contents: read`.
  - For the job (or step) that requires more (i.e., the "Create Pull Request" step or its containing job), we overwrite with the necessary write permissions (`contents: write` and `pull-requests: write`).
  - In this case, since all the steps are in a single job (`generate`), we can set permissions at this job level to match the requirements: `contents: write`, `pull-requests: write`.
  - If you prefer to be even stricter and set only `contents: read` at the workflow level and override just for the step/job that requires more, you can nest permissions accordingly.
  For simplicity and safety, set at the job level:  
  ```yaml
  permissions:
  contents: write
  pull-requests: write
  ```
  Add this under the job definition (`generate:`), on the same indentation level as `runs-on:`.

  ---
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
